### PR TITLE
Feature: better send

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ QueueWrapper.prototype.send = function (address, data, done) {
   } else {
     const serializedData = typeof data === 'object' ? JSON.stringify(data) : data
     const encodedData = new Buffer(serializedData).toString('base64')
-    options.message = `${address}|[[${encodedData}]]`
+    options.message = `${address}:[[${encodedData}]]`
   }
 
   const send = () => {

--- a/index.js
+++ b/index.js
@@ -36,23 +36,21 @@ QueueWrapper.prototype.initialiseQueue = function () {
 
 // public send function
 QueueWrapper.prototype.send = function (address, data, done) {
-  let message = ''
+  const options = {
+    qname: this.options.name
+  }
+
   if (typeof data === 'function') {
     done = data
-    message = address
+    options.message = address
   } else {
     const serializedData = typeof data === 'object' ? JSON.stringify(data) : data
     const encodedData = new Buffer(serializedData).toString('base64')
-    message = address + '|' + encodedData
+    options.message = `${address}|[[${encodedData}]]`
   }
 
   const send = () => {
-    let options = {
-      qname: this.options.name,
-      message: message,
-      delay: this.getDelay(message)
-    }
-
+    options.delay = this.getDelay(options.message)
     this.rsmq.sendMessage(options, done)
   }
 

--- a/index.js
+++ b/index.js
@@ -53,8 +53,6 @@ QueueWrapper.prototype.send = function (address, data, done) {
       delay: this.getDelay(message)
     }
 
-    console.log(options)
-
     this.rsmq.sendMessage(options, done)
   }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,17 @@ QueueWrapper.prototype.initialiseQueue = function () {
 }
 
 // public send function
-QueueWrapper.prototype.send = function (message, done) {
+QueueWrapper.prototype.send = function (address, data, done) {
+  let message = ''
+  if (typeof data === 'function') {
+    done = data
+    message = address
+  } else {
+    const serializedData = typeof data === 'object' ? JSON.stringify(data) : data
+    const encodedData = new Buffer(serializedData).toString('base64')
+    message = address + '|' + encodedData
+  }
+
   const send = () => {
     let options = {
       qname: this.options.name,

--- a/test/queue.js
+++ b/test/queue.js
@@ -111,10 +111,10 @@ describe('QueueWrapper', function (done) {
 
       // send is faked above, so the response should contain the options
       // created by the queueWrapper to be sent as the message to the real queue
-      queueWrapper.send('worker|message', (response) => {
+      queueWrapper.send('worker:message', (response) => {
         should.exist(response.qname)
         should.exist(response.message)
-        response.message.should.equal('worker|message')
+        response.message.should.equal('worker:message')
         done()
       })
     })
@@ -131,7 +131,7 @@ describe('QueueWrapper', function (done) {
       queueWrapper.send('worker', { 'test': true }, (response) => {
         should.exist(response.qname)
         should.exist(response.message)
-        response.message.substr(0, 7).should.equal('worker|')
+        response.message.substr(0, 7).should.equal('worker:')
         done()
       })
     })

--- a/test/queue.js
+++ b/test/queue.js
@@ -100,6 +100,44 @@ describe('QueueWrapper', function (done) {
       })
     })
 
+    it ('should send a message when a string is passed', function (done) {
+      queueWrapper = new QueueWrapper({
+        name: 'myqueue'
+      })
+
+      fakeRsmq.emit('connect', () => {
+
+      })
+
+      // send is faked above, so the response should contain the options
+      // created by the queueWrapper to be sent as the message to the real queue
+      queueWrapper.send('worker|message', (response) => {
+        should.exist(response.qname)
+        should.exist(response.message)
+        response.message.should.equal('worker|message')
+        done()
+      })
+    })
+
+    it ('should send a message when an address and object are passed', function (done) {
+      queueWrapper = new QueueWrapper({
+        name: 'myqueue'
+      })
+
+      fakeRsmq.emit('connect', () => {
+
+      })
+
+      // send is faked above, so the response should contain the options
+      // created by the queueWrapper to be sent as the message to the real queue
+      queueWrapper.send('worker', { 'test': true }, (response) => {
+        should.exist(response.qname)
+        should.exist(response.message)
+        response.message.substr(0, 7).should.equal('worker|')
+        done()
+      })
+    })
+
     it ('should return error when not connected', function (done) {
       queueWrapper = new QueueWrapper({
         name: 'myqueue'

--- a/test/queue.js
+++ b/test/queue.js
@@ -119,7 +119,7 @@ describe('QueueWrapper', function (done) {
       })
     })
 
-    it ('should send a message when an address and object are passed', function (done) {
+    it ('should start a message with address when an address and object are passed', function (done) {
       queueWrapper = new QueueWrapper({
         name: 'myqueue'
       })
@@ -128,12 +128,30 @@ describe('QueueWrapper', function (done) {
 
       })
 
-      // send is faked above, so the response should contain the options
-      // created by the queueWrapper to be sent as the message to the real queue
       queueWrapper.send('worker', { 'test': true }, (response) => {
         should.exist(response.qname)
         should.exist(response.message)
         response.message.substr(0, 7).should.equal('worker|')
+        done()
+      })
+    })
+
+    it ('should encapsulate the data with [[ ]] when an address and object are passed', function (done) {
+      queueWrapper = new QueueWrapper({
+        name: 'myqueue'
+      })
+
+      fakeRsmq.emit('connect', () => {
+
+      })
+
+      queueWrapper.send('worker', { 'test': true }, (response) => {
+        should.exist(response.qname)
+        should.exist(response.message)
+
+        const messageData = response.message.substr(7)
+        messageData.startsWith('[[').should.equal(true)
+        messageData.endsWith(']]').should.equal(true)
         done()
       })
     })


### PR DESCRIPTION
Fixes #4 
Requires https://github.com/dadi/queue/pull/9

This PR allows `send()` to be used with an address (i.e. `path:to:worker`) and an object, rather than a manually constructed string. 

The data packet is constructed in the standard method:

```
const serializedData = typeof data === 'object' ? JSON.stringify(data) : data
const encodedData = new Buffer(serializedData).toString('base64')
const message = address + '|' + encodedData
```

Note: the Queue worker is still responsible for decoding and splitting this string.